### PR TITLE
Golang 1.5+ requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
 go:
-    - 1.4
     - 1.5
     - 1.6
+    - 1.7
+    - 1.8
 
 script:
     - ./test.sh


### PR DESCRIPTION
prometheus [officially requires golang 1.5](https://github.com/prometheus/prometheus#building-from-source). This patch is removing 1.4 from the travis build configuration (as it is failing currently) in favor of adding golang 1.7 and 1.8 build steps.