### PR TITLE
Support adding more than one pClient targeting the same promRegistry

### DIFF
--- a/prometheusmetrics.go
+++ b/prometheusmetrics.go
@@ -51,7 +51,7 @@ func (c *PrometheusConfig) gaugeFromNameAndValue(name string, val float64) {
 			Name:      c.flattenKey(name),
 			Help:      name,
 		})
-		c.promRegistry.MustRegister(g)
+		c.promRegistry.Register(g)
 		c.gauges[key] = g
 	}
 	g.Set(val)


### PR DESCRIPTION
If the target Prometheus Registry has some metrics already registered (for
instance, by an previous run of `UpdatePrometheusMetrics()`), trying to create a
new `(*PrometheusConfig)` targetting the same Prometheus Registry will produce a
panic, since `MustRegister()` will die if an error occurs.

Simply replacing `MustRegister()` with Register() will enable this flow without
killing the process, since `MustRegister()` will not panic, but instead return an
error.

Why is this an issue?  In our use case, we instantiate a server which creates the goroutine with the `pClient.UpdatePrometheusMetricsOnce()`.  When running in production-ish mode, this happens exactly once per process.  But when running the tests, we often create and destroy this server several times in a row, in the same process, along with the goroutine that calls `pClient.UpdatePrometheusMetricsOnce()`.  As it goes, the second time that happens, the call to `MustRegister()` within `gaugeFromNameAndValue()` abruptly ends the process with a nice `panic`, which kinda spoils the fun for us.

We've changed `MustRegister()` with the more lax `Register()`, aiming towards the idempotence of the update process.

Note that in no way are we trying to run two updaters concurrently.

Thanks for your time.

Co-authored-by: Jose Luis Lucas <joseluis.lucas.simarro@bbva.com>