### PR TITLE
Fix broken go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tumani1/go-metrics-prometheus
+module github.com/deathowl/go-metrics-prometheus
 
 go 1.13
 


### PR DESCRIPTION
This change fixes the module name in the go.mod file following PR #11, which resulted in broken importing:

```
$ go get ...
...
go get: github.com/deathowl/go-metrics-prometheus@v0.0.0-20190530215645-35bace25558f updating to
	github.com/deathowl/go-metrics-prometheus@v0.0.0-20200324212232-ac8d39ebb009: parsing go.mod:
	module declares its path as: github.com/tumani1/go-metrics-prometheus
	        but was required as: github.com/deathowl/go-metrics-prometheus
```