### PR TITLE
Fix to go mod reference for Upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tumani1/go-metrics-prometheus
+module github.com/deathowl/go-metrics-prometheus
 
 go 1.13
 


### PR DESCRIPTION
Need a quick fix here so that we don't run into the issue for `go get`

```
go get: github.com/deathowl/go-metrics-prometheus@v0.0.0-20200324212232-ac8d39ebb009: parsing go.mod:
        module declares its path as: github.com/tumani1/go-metrics-prometheus
                but was required as: github.com/deathowl/go-metrics-prometheus
```