### PR TITLE
Use flattened name in description

### DIFF
--- a/prometheusmetrics.go
+++ b/prometheusmetrics.go
@@ -125,7 +125,7 @@ func (c *PrometheusConfig) histogramFromNameAndMetric(name string, goMetric inte
 			c.flattenKey(c.subsystem),
 			fmt.Sprintf("%s_%s", c.flattenKey(name), typeName),
 		),
-		name,
+		c.flattenKey(name),
 		[]string{},
 		map[string]string{},
 	)


### PR DESCRIPTION
Use the flattened name for the `help` argument when building the prometheus description since the name parameter uses flattened version as well.

Without this, you can get an error like: 
`has help "name_for-example" but should have "name_for_example"` (notice the difference between the hyphen and the underscore between `for` and `example`)