### PR TITLE
Add more metrics of Meters and Timers to Prometheus registry

### DIFF
--- a/prometheusmetrics.go
+++ b/prometheusmetrics.go
@@ -156,22 +156,34 @@ func (c *PrometheusConfig) UpdatePrometheusMetricsOnce() error {
 		case metrics.Gauge:
 			c.gaugeFromNameAndValue(name, float64(metric.Value()))
 		case metrics.GaugeFloat64:
-			c.gaugeFromNameAndValue(name, float64(metric.Value()))
+			c.gaugeFromNameAndValue(name, metric.Value())
 		case metrics.Histogram:
 			samples := metric.Snapshot().Sample().Values()
 			if len(samples) > 0 {
 				lastSample := samples[len(samples)-1]
 				c.gaugeFromNameAndValue(name, float64(lastSample))
 			}
-
 			c.histogramFromNameAndMetric(name, metric, c.histogramBuckets)
 		case metrics.Meter:
-			lastSample := metric.Snapshot().Rate1()
-			c.gaugeFromNameAndValue(name, float64(lastSample))
+			snapshot := metric.Snapshot()
+			c.gaugeFromNameAndValue(name+"_rate1", snapshot.Rate1())
+			c.gaugeFromNameAndValue(name+"_rate5", snapshot.Rate5())
+			c.gaugeFromNameAndValue(name+"_rate15", snapshot.Rate15())
+			c.gaugeFromNameAndValue(name+"_rate_mean", snapshot.RateMean())
+			c.gaugeFromNameAndValue(name+"_count", float64(snapshot.Count()))
 		case metrics.Timer:
-			lastSample := metric.Snapshot().Rate1()
-			c.gaugeFromNameAndValue(name, float64(lastSample))
-
+			snapshot := metric.Snapshot()
+			c.gaugeFromNameAndValue(name+"_rate1", snapshot.Rate1())
+			c.gaugeFromNameAndValue(name+"_rate5", snapshot.Rate5())
+			c.gaugeFromNameAndValue(name+"_rate15", snapshot.Rate15())
+			c.gaugeFromNameAndValue(name+"_rate_mean", snapshot.RateMean())
+			c.gaugeFromNameAndValue(name+"_count", float64(snapshot.Count()))
+			c.gaugeFromNameAndValue(name+"_sum", float64(snapshot.Sum()))
+			c.gaugeFromNameAndValue(name+"_max", float64(snapshot.Max()))
+			c.gaugeFromNameAndValue(name+"_min", float64(snapshot.Min()))
+			c.gaugeFromNameAndValue(name+"_mean", snapshot.Mean())
+			c.gaugeFromNameAndValue(name+"_variance", snapshot.Variance())
+			c.gaugeFromNameAndValue(name+"_std_dev", snapshot.StdDev())
 			c.histogramFromNameAndMetric(name, metric, c.timerBuckets)
 		}
 	})


### PR DESCRIPTION
Hi.

Meters and Timers have quite a lot of methods to acquire rates, counts and other stuff, but not all of them are published to Prometheus registry. I suppose they can be useful in certain situations, thus this PR adds missing metrics to registry as gauges.

Some of the metrics are still missing (like percentiles) - my guess is to choose a number of the most useful of them (for example, 25%, 50%, 75%, 90%, 95%, 99%) and add them as gauges as well.

Big thanks for the library, by the way :)